### PR TITLE
Updated links to block explorer

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ title: TurtleTurtle.org
 [github.turtlecoin.lol](https://github.com/turtlecoin) → Development  
 
 ### Block Explorers
-[explorer.turtlecoin.lol](http://explorer.turtlecoin.lol) → Watter's Block Explorer  
+[turtle-coin.com](http://turtle-coin.com) → Watter's Block Explorer  
 [blocks.turtle.link](https://blocks.turtle.link) → Tom's Block Explorer and APIs  
 [turtle-block.com](https://turtle-block.com) → Cision's Block Explorer
 


### PR DESCRIPTION
Changed [explorer.turtlecoin.lol](http://explorer.turtlecoin.lol) → Watter's Block Explorer to correct link